### PR TITLE
Fix use of options to not override options property of EmberAddon super class

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
       return;
     let config = baseConfig['responsive-image'];
     let url = baseConfig.rootURL || baseConfig.baseURL || '';
-    this.options = [];
+    this.addonOptions = [];
 
     if (Array.isArray(config) === false) {
       config = [config];
@@ -58,7 +58,7 @@ module.exports = {
     config.forEach((item) => {
       let extendedConfig = extend(defaultConfig(env), item);
       extendedConfig.rootURL = url;
-      this.options.push(extendedConfig);
+      this.addonOptions.push(extendedConfig);
     })
   },
 
@@ -95,7 +95,7 @@ module.exports = {
         this.metaData.prepend = this.app.options.fingerprint.prepend;
       }
       let trees = [];
-      this.options.forEach((options) => {
+      this.addonOptions.forEach((options) => {
         let imageTree = this.resizeImages(tree, options)
         trees.push(imageTree);
       });
@@ -120,7 +120,7 @@ module.exports = {
   },
 
   postBuild(result) {
-    this.options.forEach((options) => {
+    this.addonOptions.forEach((options) => {
       if (options.removeSourceDir) {
         // remove folder with source files
         rimraf.sync(path.join(result.directory, options.sourceDir));


### PR DESCRIPTION
`this.options` is already used in the super class. When overriding this, this has the side effect of triggering the following warning since ember-cli 2.12:

```
DEPRECATION: Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. `ember-responsive-image` (found at `/Users/simonihmig/Projects/tlw/node_modules/ember-responsive-image`) has overridden the `this.options.babel` options which conflicts with the addons ability to transpile its `addon/` files properly. Falling back to default babel configuration options.
```