### PR TITLE
Add setupResponsiveImage test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,25 +265,15 @@ For lazy-loading and LQIP support, see [ember-lazy-responsive-image](https://git
 
 ## Tests
 
-Sometimes you can get in trouble in integration tests and get an assertion `'There is no data for image ...'` if your subject relates to this addon. Because the `ResponsiveImageService` get necessary data injected in the instance-initializer, and the instance-initializers won't be called in the integration tests. To fix this, you can call the instance-initializer yourself in the tests:
+Sometimes you can get in trouble in integration tests and get an assertion `'There is no data for image ...'` if your subject relates to this addon. Because the `ResponsiveImageService` gets necessary data injected in an instance-initializer, and instance-initializers won't be called in the integration tests. To fix this, you can provided ``setupResponsiveImage()` test helper in tests:
 
 ```js
-import { initialize } from 'ember-responsive-image/instance-initializers/responsive-meta';
-// ...
-// assume using mocha
-import { before, describe} from 'mocha';
-import { setupComponentTest} from 'ember-mocha';
+import { setupRenderingTest} from 'ember-qunit';
+import { setupResponsiveImage } from 'ember-responsive-image/test-support';
 
-describe(
-  'Integration: My Image Component',
-  function() {
-    setupComponentTest('my-image', {
-      integration: true
-    });
-    before(function() {
-      initialize();
-    });
-    // ....your tests here
-  }
-);
+module('Integration: My Image Component', function(hooks) {
+  setupResponsiveImage(hooks);
+
+  test(...);
+});
 ```

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,5 @@
+import { initialize } from 'ember-responsive-image/instance-initializers/responsive-meta';
+
+export function setupResponsiveImage(hooks = self) {
+  hooks.beforeEach(initialize);
+}

--- a/tests/integration/components/responsive-background-test.js
+++ b/tests/integration/components/responsive-background-test.js
@@ -1,28 +1,24 @@
 import { find, render } from '@ember/test-helpers';
 import { expect } from 'chai';
-import { initialize } from 'ember-responsive-image/instance-initializers/responsive-meta';
+import { setupResponsiveImage } from 'ember-responsive-image/test-support';
 import {
   setupRenderingTest
 } from 'ember-mocha';
 import {
-  it, 
-  before,
+  it,
   describe
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration: ResponsiveBackgroundComponent', function() {
-  setupRenderingTest();
-  
-  before(function() {
-    initialize();
-  });
-  
+  let hooks = setupRenderingTest();
+  setupResponsiveImage(hooks);
+
   it('renders with backround url', async function() {
     await render(hbs`{{responsive-background image="test.png"}}`);
     expect(find('div[style]').getAttribute('style')).to.equal('background-image: url(\'/assets/images/responsive/test100w-00e24234f1b58e32b935b1041432916f.png\');');
   });
-  
+
   it('it renders the background url next to needed display size', async function() {
     let service = this.owner.lookup('service:responsive-image');
     service.set('physicalWidth', 45);
@@ -32,7 +28,7 @@ describe('Integration: ResponsiveBackgroundComponent', function() {
     await render(hbs`{{responsive-background image="test.png"}}`);
     expect(find('div[style]').getAttribute('style')).to.equal('background-image: url(\'/assets/images/responsive/test100w-00e24234f1b58e32b935b1041432916f.png\');');
   });
-  
+
   it('it renders the background url next to given render size', async function() {
     this.owner.lookup('service:responsive-image')
       .set('physicalWidth', 100);

--- a/tests/integration/components/responsive-image-test.js
+++ b/tests/integration/components/responsive-image-test.js
@@ -1,64 +1,59 @@
 import { find, render } from '@ember/test-helpers';
 import { expect } from 'chai';
-import { initialize } from 'ember-responsive-image/instance-initializers/responsive-meta';
+import { setupResponsiveImage } from 'ember-responsive-image/test-support';
 import {
   setupRenderingTest
 } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import {
   it,
-  before,
   describe
 } from 'mocha';
 
 describe('Integration: Responsive Image Component', function() {
-    setupRenderingTest();
-    
-    before(function() {
-      initialize();
-    });
-    
-    it('it renders the correct sourceset', async function() {
-      await render(hbs`{{responsive-image image="test.png"}}`);
-      expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/responsive/test100w-00e24234f1b58e32b935b1041432916f.png 100w');
-      expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/responsive/test50w-00e24234f1b58e32b935b1041432916f.png 50w');
-      await render(hbs`{{responsive-image image="small.png"}}`);
-      expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/smallresponsive/small10w-00e24234f1b58e32b935b1041432916f.png 10w');
-      expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/smallresponsive/small25w-00e24234f1b58e32b935b1041432916f.png 25w');
-    });
+  let hooks = setupRenderingTest();
+  setupResponsiveImage(hooks);
 
-    it('it renders a given size as sizes', async function() {
-      await render(hbs`{{responsive-image image="test.png" size="40"}}`);
-      expect(find('img').getAttribute('sizes')).to.equal('40vw');
-    });
+  it('it renders the correct sourceset', async function() {
+    await render(hbs`{{responsive-image image="test.png"}}`);
+    expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/responsive/test100w-00e24234f1b58e32b935b1041432916f.png 100w');
+    expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/responsive/test50w-00e24234f1b58e32b935b1041432916f.png 50w');
+    await render(hbs`{{responsive-image image="small.png"}}`);
+    expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/smallresponsive/small10w-00e24234f1b58e32b935b1041432916f.png 10w');
+    expect(find('img').getAttribute('srcset')).to.have.string('/assets/images/smallresponsive/small25w-00e24234f1b58e32b935b1041432916f.png 25w');
+  });
 
-    it('it renders with given sizes', async function() {
-      await render(hbs`{{responsive-image image="test.png" sizes="(max-width: 767px) 100vw, 50vw"}}`);
-      expect(find('img').getAttribute('sizes')).to.equal('(max-width: 767px) 100vw, 50vw');
-    });
+  it('it renders a given size as sizes', async function() {
+    await render(hbs`{{responsive-image image="test.png" size="40"}}`);
+    expect(find('img').getAttribute('sizes')).to.equal('40vw');
+  });
 
-    it('it renders the fallback src next to needed display size', async function() {
-      let service = this.owner.lookup('service:responsive-image');
-      service.set('physicalWidth', 45);
-      await render(hbs`{{responsive-image image="test.png"}}`);
-      expect(find('img').getAttribute('src')).to.equal('/assets/images/responsive/test50w-00e24234f1b58e32b935b1041432916f.png');
-      service.set('physicalWidth', 51);
-      await render(hbs`{{responsive-image image="test.png"}}`);
-      expect(find('img').getAttribute('src')).to.equal('/assets/images/responsive/test100w-00e24234f1b58e32b935b1041432916f.png');
-      service.set('physicalWidth', 9);
-      await render(hbs`{{responsive-image image="small.png"}}`);
-      expect(find('img').getAttribute('src')).to.equal('/assets/images/smallresponsive/small10w-00e24234f1b58e32b935b1041432916f.png');
-      service.set('physicalWidth', 11);
-      await render(hbs`{{responsive-image image="small.png"}}`);
-      expect(find('img').getAttribute('src')).to.equal('/assets/images/smallresponsive/small25w-00e24234f1b58e32b935b1041432916f.png');
-    });
-    
-    it('it renders the alt and classNames arguments', async function() {
-      this.set('alt', 'my description');
-      this.set('className', 'my-css-class');
-      await render(hbs`{{responsive-image image="test.png" alt=alt className=className}}`);
-      expect(find('img').getAttribute('alt')).to.equal('my description');
-      expect(find('img').getAttribute('class')).to.contain('my-css-class');
-    });
-  }
-);
+  it('it renders with given sizes', async function() {
+    await render(hbs`{{responsive-image image="test.png" sizes="(max-width: 767px) 100vw, 50vw"}}`);
+    expect(find('img').getAttribute('sizes')).to.equal('(max-width: 767px) 100vw, 50vw');
+  });
+
+  it('it renders the fallback src next to needed display size', async function() {
+    let service = this.owner.lookup('service:responsive-image');
+    service.set('physicalWidth', 45);
+    await render(hbs`{{responsive-image image="test.png"}}`);
+    expect(find('img').getAttribute('src')).to.equal('/assets/images/responsive/test50w-00e24234f1b58e32b935b1041432916f.png');
+    service.set('physicalWidth', 51);
+    await render(hbs`{{responsive-image image="test.png"}}`);
+    expect(find('img').getAttribute('src')).to.equal('/assets/images/responsive/test100w-00e24234f1b58e32b935b1041432916f.png');
+    service.set('physicalWidth', 9);
+    await render(hbs`{{responsive-image image="small.png"}}`);
+    expect(find('img').getAttribute('src')).to.equal('/assets/images/smallresponsive/small10w-00e24234f1b58e32b935b1041432916f.png');
+    service.set('physicalWidth', 11);
+    await render(hbs`{{responsive-image image="small.png"}}`);
+    expect(find('img').getAttribute('src')).to.equal('/assets/images/smallresponsive/small25w-00e24234f1b58e32b935b1041432916f.png');
+  });
+
+  it('it renders the alt and classNames arguments', async function() {
+    this.set('alt', 'my description');
+    this.set('className', 'my-css-class');
+    await render(hbs`{{responsive-image image="test.png" alt=alt className=className}}`);
+    expect(find('img').getAttribute('alt')).to.equal('my description');
+    expect(find('img').getAttribute('class')).to.contain('my-css-class');
+  });
+});


### PR DESCRIPTION
This allows us to treat the instance-initializer as a private thing (should the way we setup the service change), and only expose the helper as a public API.