### PR TITLE
Update sharp and testing infrastructure, drop node < 10 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,8 +38,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "10"
 
-sudo: false
 dist: trusty
 
 addons:
   chrome: stable
 
 cache:
-  yarn: true
+  directories:
+    - $HOME/.npm
 
 env:
   global:
@@ -26,37 +26,50 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:
     # runs linting and tests with current locked deps
-
     - stage: "Tests"
       name: "Tests"
       script:
-        - yarn run lint:hbs
-        - yarn run lint:js
-        - yarn test
+        - npm run lint
+        - npm run test:ember
+
+    - stage: "Tests"
+      name: "Node 12 Tests"
+      node_js: 12
+      script:
+        - npm run test:ember
+
+    - stage: "Tests"
+      name: "Node 14 Tests"
+      node_js: 14
+      script:
+        - npm run test:ember
+
+    - stage: "Additional Tests"
+      name: "Floating Dependencies"
+      install:
+        - npm install --no-package-lock
+      script:
+        - npm run test:ember
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=fastboot-addon-tests
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
-
-install:
-  - yarn install
-
 script:
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,80 +2,116 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.16',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.16.0'
-            }
-          }
+module.exports = async function() {
+  return {
+    scenarios: [
+      {
+        name: 'ember-lts-2.16',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
         },
-        {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0'
-            }
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1',
+            'ember-source': '~2.16.0'
           }
-        },
-        {
-          name: 'ember-release',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[0]
-            }
-          }
-        },
-        {
-          name: 'ember-beta',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[1]
-            }
-          }
-        },
-        {
-          name: 'ember-canary',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[2]
-            }
-          }
-        },
-        {
-          name: 'ember-default-with-jquery',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true
-            })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1'
-            }
-          }
-        },
-        {
-          name: 'fastboot-addon-tests',
-          command: 'yarn test:fastboot'
         }
-      ]
-    };
-  });
+      },
+      {
+        name: 'ember-lts-2.18',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1',
+            'ember-source': '~2.18.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.4.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.8.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0'
+          }
+        }
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release')
+          }
+        }
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta')
+          }
+        }
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary')
+          }
+        }
+      },
+      // The default `.travis.yml` runs this scenario via `npm test`,
+      // not via `ember try`. It's still included here so that running
+      // `ember try:each` manually or from a customized CI config will run it
+      // along with all the other scenarios.
+      {
+        name: 'ember-default',
+        npm: {
+          devDependencies: {}
+        }
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'jquery-integration': true
+          })
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1'
+          }
+        }
+      },
+      {
+        name: 'fastboot-addon-tests',
+        command: 'npm run test:fastboot'
+      }
+    ]
+  };
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "broccoli-stew": "^2.0.1",
     "ember-cli-babel": "^7.1.2",
     "fs-extra": "^7.0.1",
-    "sharp": "^0.21.1"
+    "sharp": "^0.25.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,18 @@
   "version": "1.0.0-rc.6",
   "description": "An ember addon that generates resized images and use them in img-tags with the srcset-attribute.",
   "scripts": {
-    "build": "ember build",
+    "build": "ember build --environment=production",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "ember test",
-    "test:all": "ember try:each",
+    "test": "npm-run-all lint:* test:*",
+    "test:ember": "ember test",
+    "test:ember-compatibility": "ember try:each",
     "test:fastboot": "ember fastboot:test"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.* || >= 12"
   },
   "dependencies": {
     "async-q": "^0.3.1",
@@ -27,6 +29,7 @@
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
+    "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^6.0.0",
     "ember-cli": "~3.6.0",
@@ -58,6 +61,7 @@
     "jpegquality": "^0.1.7",
     "loader.js": "^4.7.0",
     "mocha": "^5.2.0",
+    "npm-run-all": "^4.1.5",
     "request": "^2.83.0",
     "rsvp": "^4.7.0"
   },

--- a/testem.js
+++ b/testem.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -7,13 +9,13 @@ module.exports = {
   launch_in_dev: [
     'Chrome'
   ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
This PR is primarily to update the version of `sharp` that is a dependency of this addon. I have noticed that it's not possible to install in any version of Node > 10 so I figured that an upgrade might fix that.

I also added a bit of a more modern travis.yml layout (using ember-cli-update) so we can more easily add tests for different versions of Node.

I tried to keep the number of changes as low as possible to hopefully get this mergeable without too many issues, but feel free to let me know if you want me to change anything 👍 

Fixes #51 
Closes https://github.com/kaliber5/ember-responsive-image/pull/53
Closes https://github.com/kaliber5/ember-responsive-image/pull/52