### PR TITLE
Apply LQIP styles with dynamically generated CSS, to support FastBoot

### DIFF
--- a/addon/components/responsive-image.hbs
+++ b/addon/components/responsive-image.hbs
@@ -10,14 +10,12 @@
     src={{this.src}}
     width={{this.width}}
     height={{this.height}}
-    class="eri-{{this.layout}}"
+    class={{this.classNames}}
     loading="lazy"
     decoding="async"
     ...attributes
     {{style
-      (if this.showLqipImage (hash background-image=this.lqipImage background-size="cover"))
       (if this.showLqipBlurhash (hash background-image=this.lqipBlurhash background-size="cover"))
-      (if this.showLqipColor (hash background-color=this.lqipColor))
     }}
     {{on "load" this.onLoad}}
   />

--- a/addon/components/responsive-image.ts
+++ b/addon/components/responsive-image.ts
@@ -22,6 +22,7 @@ interface ResponsiveImageComponentArgs {
   sizes?: string;
   width?: number;
   height?: number;
+  cacheBreaker?: string;
 }
 
 interface PictureSource {
@@ -76,7 +77,12 @@ export default class ResponsiveImageComponent extends Component<ResponsiveImageC
         .map((type) => {
           const sources: string[] = this.responsiveImage
             .getImages(this.args.src, type)
-            .map((imageMeta) => `${imageMeta.image} ${imageMeta.width}w`);
+            .map(
+              (imageMeta) =>
+                `${imageMeta.image}${
+                  this.args.cacheBreaker ? '?' + this.args.cacheBreaker : ''
+                } ${imageMeta.width}w`
+            );
 
           return {
             srcset: sources.join(', '),
@@ -103,7 +109,9 @@ export default class ResponsiveImageComponent extends Component<ResponsiveImageC
               type
             )!;
 
-            return `${imageMeta.image} ${density}x`;
+            return `${imageMeta.image}${
+              this.args.cacheBreaker ? '?' + this.args.cacheBreaker : ''
+            } ${density}x`;
           }).filter((source) => source !== undefined);
 
           return {
@@ -143,7 +151,11 @@ export default class ResponsiveImageComponent extends Component<ResponsiveImageC
    * the image source which fits at best for the size and screen
    */
   get src(): string | undefined {
-    return this.imageMeta?.image;
+    return this.imageMeta
+      ? `${this.imageMeta.image}${
+          this.args.cacheBreaker ? '?' + this.args.cacheBreaker : ''
+        }`
+      : undefined;
   }
 
   get width(): number | undefined {

--- a/addon/components/responsive-image.ts
+++ b/addon/components/responsive-image.ts
@@ -4,19 +4,12 @@ import ResponsiveImageService, {
   ImageMeta,
   ImageType,
   LqipBlurhash,
-  LqipColor,
-  LqipInline,
   Meta,
 } from 'ember-responsive-image/services/responsive-image';
 import { assert } from '@ember/debug';
-import dataUri from 'ember-responsive-image/utils/data-uri';
-import blurrySvg from 'ember-responsive-image/utils/blurry-svg';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import {
-  macroCondition,
-  getOwnConfig /*, importSync*/,
-} from '@embroider/macros';
+import { getOwnConfig, macroCondition } from '@embroider/macros';
 import { decode } from 'blurhash';
 
 declare module '@embroider/macros' {
@@ -187,47 +180,17 @@ export default class ResponsiveImageComponent extends Component<ResponsiveImageC
     }
   }
 
-  get hasLqipImage(): boolean {
-    return this.meta.lqip?.type === 'inline';
-  }
-
-  get showLqipImage(): boolean {
-    return !this.isLoaded && this.hasLqipImage;
-  }
-
-  get lqipImage(): string | undefined {
-    if (!this.hasLqipImage) {
-      return undefined;
+  get classNames(): string {
+    const classNames = [`eri-${this.layout}`];
+    const lqip = this.meta.lqip;
+    if (lqip && !this.isLoaded) {
+      classNames.push(`eri-lqip-${lqip.type}`);
+      if (lqip.type === 'color' || lqip.type === 'inline') {
+        classNames.push(lqip.class);
+      }
     }
-    const lqip = (this.meta as Required<Meta>).lqip as LqipInline;
 
-    const uri = dataUri(
-      blurrySvg(
-        dataUri(lqip.image, 'image/png', true),
-        lqip.width,
-        lqip.height
-      ),
-      'image/svg+xml'
-    );
-
-    return `url("${uri}")`;
-  }
-
-  get hasLqipColor(): boolean {
-    return this.meta.lqip?.type === 'color';
-  }
-
-  get showLqipColor(): boolean {
-    return !this.isLoaded && this.hasLqipColor;
-  }
-
-  get lqipColor(): string | undefined {
-    if (!this.hasLqipColor) {
-      return undefined;
-    }
-    const lqip = (this.meta as Required<Meta>).lqip as LqipColor;
-
-    return lqip.color;
+    return classNames.join(' ');
   }
 
   get hasLqipBlurhash(): boolean {

--- a/addon/services/responsive-image.ts
+++ b/addon/services/responsive-image.ts
@@ -13,14 +13,12 @@ export interface LqipBase {
 
 export interface LqipInline extends LqipBase {
   type: 'inline';
-  image: string;
-  width: number;
-  height: number;
+  class: string;
 }
 
 export interface LqipColor extends LqipBase {
   type: 'color';
-  color: string;
+  class: string;
 }
 
 export interface LqipBlurhash extends LqipBase {

--- a/addon/styles/ember-responsive-image.css
+++ b/addon/styles/ember-responsive-image.css
@@ -7,3 +7,7 @@
 .eri-responsive {
   content-visibility: auto;
 }
+
+.eri-lqip-inline {
+  background-size: cover;
+}

--- a/addon/utils/data-uri.ts
+++ b/addon/utils/data-uri.ts
@@ -1,7 +1,0 @@
-export default function dataUri(
-  data: string,
-  type: string,
-  base64 = false
-): string {
-  return `data:${type};base64,${base64 ? data : btoa(data)}`;
-}

--- a/lib/css-writer.js
+++ b/lib/css-writer.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const CachingWriter = require('broccoli-caching-writer');
+const path = require('path');
+const fs = require('fs-extra');
+const baseN = require('base-n');
+
+const b64 = baseN.create();
+
+class CssWriter extends CachingWriter {
+  constructor(inputNodes, getMeta, cssExtensions, options) {
+    options = options || {};
+    options.cacheInclude = [/.*/];
+    super(inputNodes, options);
+
+    this.getMeta = getMeta;
+    this.cssExtensions = cssExtensions;
+  }
+
+  async build() {
+    const destinationPath = path.join(
+      this.outputPath,
+      'ember-responsive-image-dynamic.css'
+    );
+
+    await fs.writeFile(destinationPath, this.generateCss());
+  }
+
+  generateCss() {
+    const meta = this.getMeta();
+    let cssEntries = [];
+
+    let classCounter = 0;
+    const generateClassName = () => `eri-dyn-${b64.encode(classCounter++)}`;
+
+    for (const [image, imageMeta] of Object.entries(meta)) {
+      for (const { callback, target } of this.cssExtensions) {
+        const css = callback.call(target, image, imageMeta, {
+          generateClassName,
+        });
+        if (css) {
+          cssEntries.push(css);
+        }
+      }
+    }
+
+    return cssEntries.join(`\n`);
+  }
+}
+
+module.exports = CssWriter;

--- a/lib/plugins/lqip-color.js
+++ b/lib/plugins/lqip-color.js
@@ -5,6 +5,7 @@ class LqipColorPlugin {
 
     addon.addMetadataExtension(this.addMetaData, this);
     addon.addImagePreProcessor(this.imagePreProcessor, this);
+    addon.addCssExtension(this.addCss, this);
   }
 
   canProcessImage(config) {
@@ -24,7 +25,7 @@ class LqipColorPlugin {
       dominant.g.toString(16) +
       dominant.b.toString(16);
 
-    this.metaData.set(image, { type: 'color', color });
+    this.metaData.set(image, { color });
 
     return sharped;
   }
@@ -32,10 +33,21 @@ class LqipColorPlugin {
   addMetaData(image, metadata /*, config*/) {
     const ourMeta = this.metaData.get(image);
     if (ourMeta) {
-      metadata.lqip = ourMeta;
+      metadata.lqip = { type: 'color', class: ourMeta.class };
     }
 
     return metadata;
+  }
+
+  addCss(image, metaData, { generateClassName }) {
+    const ourMeta = this.metaData.get(image);
+    if (ourMeta) {
+      const className = generateClassName();
+      ourMeta.class = className;
+      return `.${className} { background-color: ${ourMeta.color}; }`;
+    }
+
+    return undefined;
   }
 }
 

--- a/lib/plugins/lqip-inline.js
+++ b/lib/plugins/lqip-inline.js
@@ -1,4 +1,6 @@
 const sharp = require('sharp');
+const dataUri = require('../utils/data-uri');
+const blurrySvg = require('../utils/blurry-svg');
 
 class LqipInlinePlugin {
   constructor(addon) {
@@ -7,6 +9,7 @@ class LqipInlinePlugin {
 
     addon.addMetadataExtension(this.addMetaData, this);
     addon.addImagePreProcessor(this.imagePreProcessor, this);
+    addon.addCssExtension(this.addCss, this);
   }
 
   canProcessImage(config) {
@@ -57,10 +60,29 @@ class LqipInlinePlugin {
   addMetaData(image, metadata /*, config*/) {
     const ourMeta = this.metaData.get(image);
     if (ourMeta) {
-      metadata.lqip = ourMeta;
+      metadata.lqip = { type: 'inline', class: ourMeta.class };
     }
 
     return metadata;
+  }
+
+  addCss(image, metaData, { generateClassName }) {
+    const ourMeta = this.metaData.get(image);
+    if (ourMeta) {
+      const className = generateClassName();
+      ourMeta.class = className;
+      const uri = dataUri(
+        blurrySvg(
+          dataUri(ourMeta.image, 'image/png', true),
+          ourMeta.width,
+          ourMeta.height
+        ),
+        'image/svg+xml'
+      );
+      return `.${className} { background-image: url(${uri}); }`;
+    }
+
+    return undefined;
   }
 }
 

--- a/lib/utils/blurry-svg.js
+++ b/lib/utils/blurry-svg.js
@@ -1,12 +1,8 @@
 // taken from https://github.com/google/eleventy-high-performance-blog/blob/5ed39db7fd3f21ae82ac1a8e833bf283355bd3d0/_11ty/blurry-placeholder.js#L51
 
-export default function blurrySvg(
-  src: string,
-  width: number,
-  height: number
-): string {
+module.exports = function blurrySvg(src, width, height) {
   return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 ${width} ${height}">
 <filter id="b" color-interpolation-filters="sRGB"><feGaussianBlur stdDeviation=".5"></feGaussianBlur><feComponentTransfer><feFuncA type="discrete" tableValues="1 1"></feFuncA></feComponentTransfer></filter>
 <image filter="url(#b)" preserveAspectRatio="none" height="100%" width="100%" xlink:href="${src}"></image>
 </svg>`;
-}
+};

--- a/lib/utils/data-uri.js
+++ b/lib/utils/data-uri.js
@@ -1,0 +1,5 @@
+module.exports = function dataUri(data, type, base64 = false) {
+  return `data:${type};base64,${
+    base64 ? data : Buffer.from(data).toString('base64')
+  }`;
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "async-q": "^0.3.1",
+    "base-n": "^3.0.0",
     "blurhash": "^1.1.3",
     "broccoli-caching-writer": "^3.0.3",
     "broccoli-funnel": "^3.0.3",

--- a/tests/dummy/app/templates/image.hbs
+++ b/tests/dummy/app/templates/image.hbs
@@ -1,1 +1,5 @@
-<ResponsiveImage @src="assets/images/tests/test.png"/>
+<ResponsiveImage @src="assets/images/tests/test.png" data-test-simple-image/>
+
+<ResponsiveImage @src="assets/images/tests/lqip/color.jpg" data-test-lqip-image="color"/>
+<ResponsiveImage @src="assets/images/tests/lqip/inline.jpg" data-test-lqip-image="inline"/>
+<ResponsiveImage @src="assets/images/tests/lqip/blurhash.jpg" data-test-lqip-image="blurhash"/>

--- a/tests/fastboot/image-test.js
+++ b/tests/fastboot/image-test.js
@@ -10,7 +10,35 @@ module('FastBoot | image', function (hooks) {
   test('it renders an image', async function (assert) {
     await visit('/image');
 
-    assert.dom('img').exists();
-    assert.dom('img').hasAttribute('src', '/assets/images/tests/test640w.png');
+    assert.dom('img[data-test-simple-image]').exists();
+    assert
+      .dom('img[data-test-simple-image]')
+      .hasAttribute('src', '/assets/images/tests/test640w.png');
+  });
+
+  test('it renders lqip color', async function (assert) {
+    await visit('/image');
+
+    assert.dom('img[data-test-lqip-image=color]').exists();
+    assert
+      .dom('img[data-test-lqip-image=color]')
+      .hasStyle({ 'background-color': 'rgb(88, 72, 56)' });
+  });
+
+  test('it renders lqip inline', async function (assert) {
+    await visit('/image');
+
+    assert.dom('img[data-test-lqip-image=inline]').exists();
+    assert
+      .dom('img[data-test-lqip-image=inline]')
+      .hasStyle({ 'background-size': 'cover' });
+    assert.ok(
+      window
+        .getComputedStyle(
+          document.querySelector('img[data-test-lqip-image=inline]')
+        )
+        .backgroundImage?.match(/data:image\/svg/),
+      'it has a background SVG'
+    );
   });
 });

--- a/tests/integration/components/responsive-image-test.js
+++ b/tests/integration/components/responsive-image-test.js
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
@@ -478,21 +478,25 @@ module('Integration: Responsive Image Component', function (hooks) {
         );
 
         assert.ok(
-          this.element
-            .querySelector('img')
-            .style.backgroundImage?.match(/data:image\/svg/),
+          window
+            .getComputedStyle(this.element.querySelector('img'))
+            .backgroundImage?.match(/data:image\/svg/),
           'it has a background SVG'
         );
         assert.dom('img').hasStyle({ 'background-size': 'cover' });
         assert.ok(
-          this.element.querySelector('img').style.backgroundImage?.length > 100,
+          window.getComputedStyle(this.element.querySelector('img'))
+            .backgroundImage?.length > 100,
           'the background SVG has a reasonable length'
         );
 
         await waitUntilLoaded;
+        await settled();
 
-        assert.notOk(
-          this.element.querySelector('img').style.backgroundImage,
+        assert.equal(
+          window.getComputedStyle(this.element.querySelector('img'))
+            .backgroundImage,
+          'none',
           'after image is loaded the background SVG is removed'
         );
       });
@@ -513,11 +517,9 @@ module('Integration: Responsive Image Component', function (hooks) {
         assert.dom('img').hasStyle({ 'background-color': 'rgb(88, 72, 56)' });
 
         await waitUntilLoaded;
+        await settled();
 
-        assert.notOk(
-          this.element.querySelector('img').style.backgroundColor,
-          'after image is loaded the background color is removed'
-        );
+        assert.dom('img').hasStyle({ 'background-color': 'rgba(0, 0, 0, 0)' });
       });
 
       module('blurhash', function () {
@@ -540,15 +542,18 @@ module('Integration: Responsive Image Component', function (hooks) {
           );
           assert.dom('img').hasStyle({ 'background-size': 'cover' });
           assert.ok(
-            this.element.querySelector('img').style.backgroundImage?.length >
-              100,
+            window.getComputedStyle(this.element.querySelector('img'))
+              .backgroundImage?.length > 100,
             'the background SVG has a reasonable length'
           );
 
           await waitUntilLoaded;
+          await settled();
 
-          assert.notOk(
-            this.element.querySelector('img').style.backgroundImage,
+          assert.equal(
+            window.getComputedStyle(this.element.querySelector('img'))
+              .backgroundImage,
+            'none',
             'after image is loaded the background PNG is removed'
           );
         });

--- a/tests/integration/components/responsive-image-test.js
+++ b/tests/integration/components/responsive-image-test.js
@@ -6,6 +6,10 @@ import { module, test } from 'qunit';
 module('Integration: Responsive Image Component', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.set('cacheBreaker', new Date().getTime());
+  });
+
   module('responsive layout', function () {
     test('it has responsive layout by default', async function (assert) {
       await render(hbs`<ResponsiveImage @src="assets/images/tests/test.png"/>`);
@@ -474,7 +478,7 @@ module('Integration: Responsive Image Component', function (hooks) {
         this.onload = () => setTimeout(resolve, 0);
 
         await render(
-          hbs`<ResponsiveImage @src="assets/images/tests/lqip/inline.jpg" {{on "load" this.onload}}/>`
+          hbs`<ResponsiveImage @src="assets/images/tests/lqip/inline.jpg" @cacheBreaker={{this.cacheBreaker}} {{on "load" this.onload}}/>`
         );
 
         assert.ok(
@@ -511,7 +515,7 @@ module('Integration: Responsive Image Component', function (hooks) {
         this.onload = () => setTimeout(resolve, 0);
 
         await render(
-          hbs`<ResponsiveImage @src="assets/images/tests/lqip/color.jpg" {{on "load" this.onload}}/>`
+          hbs`<ResponsiveImage @src="assets/images/tests/lqip/color.jpg" @cacheBreaker={{this.cacheBreaker}} {{on "load" this.onload}}/>`
         );
 
         assert.dom('img').hasStyle({ 'background-color': 'rgb(88, 72, 56)' });
@@ -521,42 +525,42 @@ module('Integration: Responsive Image Component', function (hooks) {
 
         assert.dom('img').hasStyle({ 'background-color': 'rgba(0, 0, 0, 0)' });
       });
+    });
 
-      module('blurhash', function () {
-        test('it sets LQIP from blurhash as background', async function (assert) {
-          let resolve;
-          const waitUntilLoaded = new Promise((r) => {
-            resolve = r;
-          });
-          this.onload = () => setTimeout(resolve, 0);
-
-          await render(
-            hbs`<ResponsiveImage @src="assets/images/tests/lqip/blurhash.jpg" {{on "load" this.onload}}/>`
-          );
-
-          assert.ok(
-            this.element
-              .querySelector('img')
-              .style.backgroundImage?.match(/data:image\/png/),
-            'it has a background PNG'
-          );
-          assert.dom('img').hasStyle({ 'background-size': 'cover' });
-          assert.ok(
-            window.getComputedStyle(this.element.querySelector('img'))
-              .backgroundImage?.length > 100,
-            'the background SVG has a reasonable length'
-          );
-
-          await waitUntilLoaded;
-          await settled();
-
-          assert.equal(
-            window.getComputedStyle(this.element.querySelector('img'))
-              .backgroundImage,
-            'none',
-            'after image is loaded the background PNG is removed'
-          );
+    module('blurhash', function () {
+      test('it sets LQIP from blurhash as background', async function (assert) {
+        let resolve;
+        const waitUntilLoaded = new Promise((r) => {
+          resolve = r;
         });
+        this.onload = () => setTimeout(resolve, 0);
+
+        await render(
+          hbs`<ResponsiveImage @src="assets/images/tests/lqip/blurhash.jpg" @cacheBreaker={{this.cacheBreaker}} {{on "load" this.onload}}/>`
+        );
+
+        assert.ok(
+          this.element
+            .querySelector('img')
+            .style.backgroundImage?.match(/data:image\/png/),
+          'it has a background PNG'
+        );
+        assert.dom('img').hasStyle({ 'background-size': 'cover' });
+        assert.ok(
+          window.getComputedStyle(this.element.querySelector('img'))
+            .backgroundImage?.length > 100,
+          'the background SVG has a reasonable length'
+        );
+
+        await waitUntilLoaded;
+        await settled();
+
+        assert.equal(
+          window.getComputedStyle(this.element.querySelector('img'))
+            .backgroundImage,
+          'none',
+          'after image is loaded the background PNG is removed'
+        );
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,6 +3719,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-n@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/base-n/-/base-n-3.0.0.tgz#a451480303130eaf73c749057e83eb272fd51377"
+  integrity sha512-u+HQjUyXwqZLbDDlunZUoFlWSZWIwIpNpDErBMOCkBU/VOMpVYMLYih/+FRFCkfrgXrdnbI46fTkUIu1C22v7Q==
+  dependencies:
+    dashdash "^1.14.1"
+
 base64-arraybuffer@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
@@ -5539,7 +5546,7 @@ dag-map@^2.0.2:
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
   integrity sha1-lxS0ct6CoYQ94vuptodpOMq0TGg=
 
-dashdash@^1.12.0:
+dashdash@^1.12.0, dashdash@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=


### PR DESCRIPTION
Instead of applying styles with JS *after* rehydration, which is too late.