### PR TITLE
Limit Blurhash size to allowed values

### DIFF
--- a/lib/plugins/lqip-blurhash.js
+++ b/lib/plugins/lqip-blurhash.js
@@ -22,7 +22,11 @@ class LqipBlurhashPlugin {
     // taken from https://github.com/google/eleventy-high-performance-blog/blob/5ed39db7fd3f21ae82ac1a8e833bf283355bd3d0/_11ty/blurry-placeholder.js#L74-L92
     let bitmapHeight = targetPixels / aspectRatio;
     bitmapHeight = Math.sqrt(bitmapHeight);
-    const bitmapWidth = targetPixels / bitmapHeight;
+    let bitmapWidth = targetPixels / bitmapHeight;
+
+    // Blurhash has a limit of 9 "components"
+    bitmapHeight = Math.min(9, Math.round(bitmapHeight));
+    bitmapWidth = Math.min(9, Math.round(bitmapWidth));
     return { width: Math.round(bitmapWidth), height: Math.round(bitmapHeight) };
   }
 


### PR DESCRIPTION
Has a limit of so called "components" (basically pixels) to be between 1 and 9.