### PR TITLE
Delay setting src attribute after <img> is in DOM to prevent extraneous image loading

### DIFF
--- a/addon/components/responsive-image.hbs
+++ b/addon/components/responsive-image.hbs
@@ -21,5 +21,6 @@
       (if this.showLqipBlurhash (hash background-image=this.lqipBlurhash background-size="cover"))
     }}
     {{on "load" this.onLoad}}
+    {{did-insert this.setRendered}}
   />
 </picture>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postpack": "ember ts:clean"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^1.0.2",
     "@embroider/macros": "^0.36.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,6 +1122,14 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
+"@ember/render-modifiers@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz#2e87c48db49d922ce4850d707215caaac60d8444"
+  integrity sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-modifier-manager-polyfill "^1.1.0"
+
 "@ember/test-helpers@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.2.1.tgz#584eb8359c4bf84670320a95e6af629d7526bc2a"
@@ -6518,7 +6526,7 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modifier-manager-polyfill@^1.2.0:
+ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==


### PR DESCRIPTION
This is an interesting problem: some browsers (FF, Safari, but not Chrome) would load an image immediately once you set the `src` attribute of `<img>`. While this is expected (think of programmatically preloading images), it poses a problem when you actually want to use the `<img>` as a child of `<picture>`, as the `src` attribute represents the fallback for browsers not supporting `<source>`.

But this is actually what happens if you render the markup in Ember: it creates the element detached from DOM (`document.createElement()`), sets the attributes (`element.setAttribute()`) and only after that attaches it to its parent. Chrome handles this more cleverly, but FF would (upon setting `src`) load the fallback image (jpeg), later sees the better `<source>` alternative (e.g. webp) and would load that *also*. Note that this does *not* happen, when the `<img>` is already part of `<picture>`, as the browser probably can understand now that the `src` attribute is not the only possible image URL.

Also all of that does not happen in a server-rendered HTML page (FastBoot, or any other server-rendered page), only when JS/Ember re-renders the page with JavaScript would that wrong behaviour show up again.

The solution seems simple enough: delay setting `src` until the `<img>` is in DOM and part of `<picture>`.