### PR TITLE
Remove warning for preProcessors on copy mode

### DIFF
--- a/lib/image-writer.js
+++ b/lib/image-writer.js
@@ -49,15 +49,6 @@ class ImageResizer extends CachingWriter {
 
     const files = this.getFiles(sourcePath, null);
 
-    if (
-      this.image_options.justCopy &&
-      (this.imagePreProcessors.length || this.imagePostProcessors.length)
-    ) {
-      this.writeWarnLine(
-        'You turned on the copy-mode and there are image-processors registered. So be aware of the image processors will be called, but their result will be ignored'
-      );
-    }
-
     let tasks = [];
     for (const file of files) {
       let image = sharp(path.join(sourcePath, file))


### PR DESCRIPTION
As we register preProcessors on our own (LQIP plugins), this warning appears all the time, which is confusing.