### PR TITLE
Disable AVIF by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ File size: **7KB**.
 
 ![a dog near the costline](docs/images/dog640w.avif)
 
+> Note: Generating AVIF files can take a lot of time, as it is very CPU-intensive. Therefore and given the limited browser support,
+the format is currently not enabled by default. You would have to opt-in, by defining the `formats` [configuration option](#configuration) to included AVIF.
+
 ## LQIP
 
 *Low Quality Image Placeholder* is a technique to give users a preview of the image while it is loading. This addon supports different types,
@@ -245,7 +248,7 @@ large images for these, so a setting of `widths: [300, 600],` would make sense h
 * **include:** Glob pattern for which images should be processed based on this configuration.
 * **exclude:** Optional pattern which images to exclude, takes precedence over `include`.
 * **widths:** These are the widths of the resized images.
-* **formats:** which image formats to produce. Supported are: `avif`, `webp`, `png` and `jpeg`. `original` is a special keyword here, representing the image format of the original source image. By default: `['original', 'webp', 'avif']`
+* **formats:** which image formats to produce. Supported are: `avif`, `webp`, `png` and `jpeg`. `original` is a special keyword here, representing the image format of the original source image. By default: `['original', 'webp']`
 * **quality:** Image quality (JPEG, WebP, AVIF)
 * **lqip:** Let's you opt into generating LQIPs, by setting at the `type`to one of the supported values. Disabled by default! 
 * **lqip.type:** `'inline'`, `'color'` or `'blurhash'`. See the [LQIP section](#lqip) for more details.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,6 +25,7 @@ module.exports = function (defaults) {
           ],
           quality: 50,
           widths: [50, 100, 640],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'color',
           },
@@ -35,11 +36,13 @@ module.exports = function (defaults) {
           quality: 10,
           removeSource: false,
           widths: [10, 25],
+          formats: ['original', 'webp', 'avif'],
         },
         {
           include: 'assets/images/tests/lqip/inline.jpg',
           quality: 50,
           widths: [100, 640],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'inline',
           },
@@ -49,6 +52,7 @@ module.exports = function (defaults) {
           include: 'assets/images/tests/lqip/color.jpg',
           quality: 50,
           widths: [100, 640],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'color',
           },
@@ -59,6 +63,7 @@ module.exports = function (defaults) {
           include: 'assets/images/tests/lqip/blurhash.jpg',
           quality: 50,
           widths: [100, 640],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'blurhash',
           },
@@ -72,6 +77,7 @@ module.exports = function (defaults) {
           ],
           quality: 50,
           widths: [1920, 1280, 640, 320],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'inline',
           },
@@ -81,6 +87,7 @@ module.exports = function (defaults) {
           include: 'assets/images/docs/lqip-color.jpg',
           quality: 50,
           widths: [1920, 1280, 640, 320],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'color',
           },
@@ -90,6 +97,7 @@ module.exports = function (defaults) {
           include: 'assets/images/docs/lqip-blurhash.jpg',
           quality: 50,
           widths: [1920, 1280, 640, 320],
+          formats: ['original', 'webp', 'avif'],
           lqip: {
             type: 'blurhash',
           },

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const defaultConfig = {
   exclude: [],
   quality: 80,
   widths: [2048, 1536, 1080, 750, 640],
-  formats: ['original', 'webp', 'avif'],
+  formats: ['original', 'webp' /*, 'avif'*/],
   removeSource: true,
   justCopy: false,
   destinationDir: '/',


### PR DESCRIPTION
As it can make the build process slow and require a lot of memory, see https://github.com/lovell/sharp/issues/2597