### PR TITLE
Support enabling blurhash explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ let app = new EmberAddon(defaults, {
 * **fingerprint**: Can be used to enable/disable fingerprinting of the generated image files. In most cases you can omit
 setting this explicitly, as it will follow whatever you have set under the main `fingerprint` options (used by the `broccoli-asset-rev` addon), 
 with the default being to enable fingerprinting only in production builds.
+* **usesBlurhash**: make the addon support blurhash explicitly. This is useful when you aren't prebuilding image data but want to use blurhash for dynamic image data included in API responses. By default it will automatically enable blurhash support when you have configured local images to use blurhash, so in general you shouldn't need to set this.
 * **deviceWidths**: an array of widths representing the typical screen widths of your user's devices, used when the available image widths are not known beforehand, like when using an image CDN.
 * **providers**: configuration for specific providers goes here, see the appropriate [provider docs](docs/providers) for more details.
 * **images**: The main configuration how the addon generated images happens here, see the following section for details.

--- a/index.js
+++ b/index.js
@@ -174,12 +174,8 @@ module.exports = {
     this.initPlugins();
     this.processingTree = this.createProcessingTree();
 
-    this.usesBlurhash =
-      this.addonOptions.usesBlurhash ||
-      this.addonOptions.images.some(
-        (imageConfig) =>
-          imageConfig.lqip && imageConfig.lqip.type === 'blurhash'
-      );
+    this._configureBlurhash();
+
     this.options['@embroider/macros'].setOwnConfig.usesBlurhash =
       this.usesBlurhash;
   },
@@ -319,6 +315,22 @@ module.exports = {
 
   _getConfig() {
     return this.project.config(this.app.env);
+  },
+
+  _configureBlurhash() {
+    const addonOptionsBlurhash = this.addonOptions.usesBlurhash;
+
+    const imagesUseBlurhash = this.addonOptions.images.some(
+      (imageConfig) => imageConfig.lqip && imageConfig.lqip.type === 'blurhash'
+    );
+
+    if (this.addonOptions.usesBlurhash === false && imagesUseBlurhash) {
+      throw new SilentError(
+        "You cannot disable blurhash support while it is still used in your images config. Please remove any instance of `lqip: { type: 'blurhash' }` from your images config."
+      );
+    }
+
+    this.usesBlurhash = addonOptionsBlurhash || imagesUseBlurhash;
   },
 
   treeForAddonStyles(tree) {

--- a/index.js
+++ b/index.js
@@ -174,9 +174,12 @@ module.exports = {
     this.initPlugins();
     this.processingTree = this.createProcessingTree();
 
-    this.usesBlurhash = this.addonOptions.images.some(
-      (imageConfig) => imageConfig.lqip && imageConfig.lqip.type === 'blurhash'
-    );
+    this.usesBlurhash =
+      this.addonOptions.usesBlurhash ||
+      this.addonOptions.images.some(
+        (imageConfig) =>
+          imageConfig.lqip && imageConfig.lqip.type === 'blurhash'
+      );
     this.options['@embroider/macros'].setOwnConfig.usesBlurhash =
       this.usesBlurhash;
   },


### PR DESCRIPTION
Thanks for this great addon!

Currently, the addon only supports using blurhash when images are optimized with this technique at build time. An app that I'm working on wants to show a lot of images but has no static images to prepare with this technique at build time.

This PR allows setting the `usesBlurhash` - option explicitly which will include the necessary things to work with blurhash even if no other static images should be rendered with this technique.

I'm not sure how to test this behavior (i.e. changing config data) but would be happy to add some tests if you can give me pointers on how to do so.



