### PR TITLE
Fix turbo: lint depends on build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,7 @@
     },
     "lint": {
       "outputs": [],
-      "dependsOn": ["^build"]
+      "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
The publint task needs `build`, `^build` is not enough. Ideally, we should have all `lint:*` tasks as spearate tutbo tasks with their own config.