### PR TITLE
fix webpack/vite install commands

### DIFF
--- a/apps/docs/src/build/vite.md
+++ b/apps/docs/src/build/vite.md
@@ -10,15 +10,15 @@
 ::: code-group
 
 ```bash [npm]
-npm install @responsive-image/vite-plugin @responsive-image/core --save-dev
+npm install -D @responsive-image/vite-plugin @responsive-image/core
 ```
 
 ```bash [yarn]
-yarn add @responsive-image/vite-plugin @responsive-image/core --dev
+yarn add -D @responsive-image/vite-plugin @responsive-image/core
 ```
 
 ```bash [pnpm]
-pnpm add @responsive-image/vite-plugin @responsive-image/core --save-dev
+pnpm add -D @responsive-image/vite-plugin @responsive-image/core
 ```
 
 :::

--- a/apps/docs/src/build/webpack.md
+++ b/apps/docs/src/build/webpack.md
@@ -10,15 +10,15 @@
 ::: code-group
 
 ```bash [npm]
-npm install @responsive-image/webpack @responsive-image/core --save-dev
+npm install -D @responsive-image/webpack @responsive-image/core
 ```
 
 ```bash [yarn]
-yarn add @responsive-image/webpack @responsive-image/core --dev
+yarn add -D @responsive-image/webpack @responsive-image/core
 ```
 
 ```bash [pnpm]
-pnpm add @responsive-image/webpack @responsive-image/core --save-dev
+pnpm add -D @responsive-image/webpack @responsive-image/core
 ```
 
 :::


### PR DESCRIPTION
I believe these package manager install commands need the `--save-dev`/`--dev` flags, otherwise the deps will be installed in the prod deps.