### PR TITLE
Revert "Update dependency @testing-library/svelte to v5.3.1"

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -50,7 +50,7 @@
 		"@responsive-image/internals": "workspace:*",
 		"@sveltejs/package": "2.5.7",
 		"@sveltejs/vite-plugin-svelte": "6.2.4",
-		"@testing-library/svelte": "5.3.1",
+		"@testing-library/svelte": "5.2.8",
 		"@tsconfig/strictest": "2.0.8",
 		"@vitest/browser": "3.2.4",
 		"concurrently": "9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1102,8 +1102,8 @@ importers:
         specifier: 6.2.4
         version: 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))
       '@testing-library/svelte':
-        specifier: 5.3.1
-        version: 5.3.1(svelte@5.48.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))(vitest@3.2.4)
+        specifier: 5.2.8
+        version: 5.2.8(svelte@5.48.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))(vitest@3.2.4)
       '@tsconfig/strictest':
         specifier: 2.0.8
         version: 2.0.8
@@ -4293,14 +4293,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@testing-library/svelte-core@1.0.0':
-    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
-
-  '@testing-library/svelte@5.3.1':
-    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+  '@testing-library/svelte@5.2.8':
+    resolution: {integrity: sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA==}
     engines: {node: '>= 10'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
@@ -15182,14 +15176,9 @@ snapshots:
       '@types/react': 19.2.9
       '@types/react-dom': 19.2.3(@types/react@19.2.9)
 
-  '@testing-library/svelte-core@1.0.0(svelte@5.48.0)':
-    dependencies:
-      svelte: 5.48.0
-
-  '@testing-library/svelte@5.3.1(svelte@5.48.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))(vitest@3.2.4)':
+  '@testing-library/svelte@5.2.8(svelte@5.48.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/svelte-core': 1.0.0(svelte@5.48.0)
       svelte: 5.48.0
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1)


### PR DESCRIPTION
This reverts commit 633d1f4e8ce8f731e379dd775b9591a150e4d504.